### PR TITLE
test: expose getFilePath failure for Astro build.format: 'file'

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -56,6 +56,37 @@ test("getFilePath blog", async () => {
   expect(normalize(result)).toBe(normalize("blog/index.html"));
 });
 
+// Astro build.format: 'file' + trailingSlash: 'never' → pathnames without a
+// trailing slash (e.g. "docs/getting-started"), HTML at docs/getting-started.html.
+// Current getFilePath uses page.slice(0, -1), which drops a real character when
+// there is no trailing slash ("getting-starte.html") and the build fails with ENOENT.
+test("getFilePath file format nested page without trailing slash", async () => {
+  const tmpDir = await createTempDir();
+  process.chdir(tmpDir);
+
+  await mkdir(join(tmpDir, "docs"));
+  await writeFile(join(tmpDir, "docs", "getting-started.html"), "");
+
+  const result = getFilePath({ dir: "", page: "docs/getting-started" });
+
+  process.chdir(__dirname);
+
+  expect(normalize(result)).toBe(normalize("docs/getting-started.html"));
+});
+
+test("getFilePath file format root index without trailing slash", async () => {
+  const tmpDir = await createTempDir();
+  process.chdir(tmpDir);
+
+  await writeFile(join(tmpDir, "index.html"), "");
+
+  const result = getFilePath({ dir: "", page: "" });
+
+  process.chdir(__dirname);
+
+  expect(normalize(result)).toBe(normalize("index.html"));
+});
+
 // https://sdorra.dev/posts/2024-02-12-vitest-tmpdir
 async function createTempDir() {
   const ostmpdir = tmpdir();


### PR DESCRIPTION
## Summary

Adds failing unit tests that demonstrate `getFilePath` breaks for Astro **`build.format: 'file'`** when `page.pathname` has **no trailing slash** (common with `trailingSlash: 'never'`).

### Observed failure

```
getFilePath({ dir: "", page: "docs/getting-started" })
// expected: docs/getting-started.html
// received: docs/getting-starte.html
```

`page.slice(0, -1)` only works when `page` ends with `/` (drops the slash). Without a trailing slash it removes a character from the slug, so the integration opens a missing HTML file and the build fails with `ENOENT`.

Existing tests only cover trailing-slash pathnames (`index/`, `404/`, `blog/`), so this regression was invisible.

### Scope of this draft

**Tests only** — intentionally red CI to document the bug. Fix in a follow-up (or on this branch once the issue is tracked).

## Test plan

- [x] `npx vitest --run src/util.test.ts` — nested file-format case fails on current `master` util (`docs/getting-starte.html` vs `docs/getting-started.html`)
- [x] Existing three tests still pass