### PR TITLE
Fix bug for image generating issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "printWidth": 120
   },
   "scripts": {
-    "prepare": "husky",
+    "prepare": "tsc",
     "lint": "eslint src --cache",
     "build": "tsc",
     "watch": "tsc -w",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "printWidth": 120
   },
   "scripts": {
-    "prepare": "tsc",
+    "prepare": "husky",
     "lint": "eslint src --cache",
     "build": "tsc",
     "watch": "tsc -w",

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -91,7 +91,7 @@ async function handlePage({ page, options, render, dir, logger, renderer, fetchC
   const imageUrl = new URL(pageDetails.image).pathname.slice(1);
 
   // check that the og:image property matches the sitePath
-  if (decodeURIComponent(imageUrl) !== decodeURIComponent(relativeImageFile)) {
+  if (decodeURIComponent(imageUrl) !== relativeImageFile) {
     throw new Error(
       `The og:image property in ${htmlFile} (${imageUrl}) does not match the generated image (${relativeImageFile}).`,
     );

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -91,7 +91,7 @@ async function handlePage({ page, options, render, dir, logger, renderer, fetchC
   const imageUrl = new URL(pageDetails.image).pathname.slice(1);
 
   // check that the og:image property matches the sitePath
-  if (imageUrl !== relativeImageFile) {
+  if (decodeURIComponent(imageUrl) !== decodeURIComponent(relativeImageFile)) {
     throw new Error(
       `The og:image property in ${htmlFile} (${imageUrl}) does not match the generated image (${relativeImageFile}).`,
     );

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -61,7 +61,15 @@ test("decodeURIComponent path matching with special characters", () => {
   const imageUrl = new URL(ogImageUrl).pathname.slice(1);
   const relativeImageFile = "archive/category/App & Tools/index.webp";
 
-  expect(decodeURIComponent(imageUrl)).toBe(decodeURIComponent(relativeImageFile));
+  expect(decodeURIComponent(imageUrl)).toBe(relativeImageFile);
+});
+
+test("decodeURIComponent path matching with literal %XX in local filename", () => {
+  const ogImageUrl = "https://example.com/archive/100%25%20discount/index.webp";
+  const imageUrl = new URL(ogImageUrl).pathname.slice(1);
+  const relativeImageFile = "archive/100% discount/index.webp";
+
+  expect(decodeURIComponent(imageUrl)).toBe(relativeImageFile);
 });
 
 // https://sdorra.dev/posts/2024-02-12-vitest-tmpdir

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -56,6 +56,14 @@ test("getFilePath blog", async () => {
   expect(normalize(result)).toBe(normalize("blog/index.html"));
 });
 
+test("decodeURIComponent path matching with special characters", () => {
+  const ogImageUrl = "https://example.com/archive/category/App%20&%20Tools/index.webp";
+  const imageUrl = new URL(ogImageUrl).pathname.slice(1);
+  const relativeImageFile = "archive/category/App & Tools/index.webp";
+
+  expect(decodeURIComponent(imageUrl)).toBe(decodeURIComponent(relativeImageFile));
+});
+
 // https://sdorra.dev/posts/2024-02-12-vitest-tmpdir
 async function createTempDir() {
   const ostmpdir = tmpdir();


### PR DESCRIPTION
Possible bug fix for #161 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image path matching for URLs containing encoded special characters, including spaces, ampersands, and percent-encoded sequences.
  * Ensured images are recognized correctly when URL encoding differs between the source URL and generated paths.

* **Tests**
  * Added coverage for decoding and matching image paths with special characters and literal encoded sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->